### PR TITLE
Improvements to watching Batch jobs

### DIFF
--- a/pyfgaws/batch/tests/test_api.py
+++ b/pyfgaws/batch/tests/test_api.py
@@ -103,7 +103,7 @@ def build_describe_jobs_response(status: Status) -> DescribeJobsResponseTypeDef:
                 "jobQueue": "job-queue",
                 "jobDefinition": "arn:aws:batch:some-arn",
                 "startedAt": 1,
-                "status": status.value,
+                "status": status.status,
             }
         ]
     }
@@ -118,23 +118,23 @@ def build_describe_jobs_responses(*status: Status) -> List[DescribeJobsResponseT
     "statuses",
     [
         [Status.Succeeded],
-        # [Status.Failed],
-        # [
-        #     Status.Submitted,
-        #     Status.Pending,
-        #     Status.Runnable,
-        #     Status.Runnable,
-        #     Status.Running,
-        #     Status.Succeeded,
-        # ],
-        # [
-        #     Status.Submitted,
-        #     Status.Pending,
-        #     Status.Runnable,
-        #     Status.Runnable,
-        #     Status.Running,
-        #     Status.Failed,
-        # ],
+        [Status.Failed],
+        [
+            Status.Submitted,
+            Status.Pending,
+            Status.Runnable,
+            Status.Runnable,
+            Status.Running,
+            Status.Succeeded,
+        ],
+        [
+            Status.Submitted,
+            Status.Pending,
+            Status.Runnable,
+            Status.Runnable,
+            Status.Running,
+            Status.Failed,
+        ],
     ],
 )
 def test_wait_for_job(statuses: List[Status]) -> None:

--- a/pyfgaws/batch/tools.py
+++ b/pyfgaws/batch/tools.py
@@ -61,8 +61,9 @@ def watch_job(*, job_id: str, region_name: Optional[str] = None, print_logs: boo
         _log_it(region_name=region_name, job=job, logger=logger)
 
     job.wait_on_complete()
+    end_status = job.get_status()
     logger.info(
-        f"Job completed with name '{job.name}', id '{job.job_id}', and status '{job.get_status()}'"
+        f"Job completed with name '{job.name}', id '{job.job_id}', and status '{end_status}'"
     )
 
 
@@ -139,9 +140,12 @@ def run_job(
             status_to_state=dict((status, True) for status in watch_until),
             after_success=after_success,
         )
-        logger.info(
-            f"Job name '{job.name}' and id '{job.job_id}' reached status '{job.get_status()}'"
-        )
+        end_status: Status = job.get_status()
+
+        if print_logs and end_status.logs:
+            _watch_logs(region_name=region_name, job=job, logger=logger, indefinitely=False)
+
+        logger.info(f"Job name '{job.name}' and id '{job.job_id}' reached status '{end_status}'")
 
 
 def _watch_logs(
@@ -149,8 +153,9 @@ def _watch_logs(
     job: BatchJob,
     logger: logging.Logger,
     polling_interval: int = DEFAULT_LOGS_POLLING_INTERVAL,
+    indefinitely: bool = True,
 ) -> None:
-    """A method to watch logs indefinitely.
+    """A method to watch logs.
 
     Args:
         region_name: the AWS region
@@ -158,6 +163,7 @@ def _watch_logs(
         logger: the logger to which logs should be printed
         polling_interval: the default time to wait for new CloudWatch logs after no more logs are
             returned
+        indefinitely: true to watch indefinitely, false to print only the available logs
     """
     # wait until it's running to get the CloudWatch logs
     job.wait_on_running()
@@ -167,8 +173,14 @@ def _watch_logs(
     )
     log: Log = Log(client=client, group="/aws/batch/job", stream=job.stream)
 
-    while True:
-        for line in log:
-            logger.info(line)
-        time.sleep(polling_interval)
-        log.reset()
+    try:
+        while True:
+            for line in log:
+                logger.info(line)
+            time.sleep(polling_interval)
+            log.reset()
+            if not indefinitely:
+                break
+    except Exception as ex:
+        logger.warning(f"Encountered an exception while watching logs: {ex}")
+        raise ex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfgaws"
-version = "0.0.2"
+version = "0.1.0"
 description = "Tools and python libraries for working with AWS."
 authors = ["Nils Homer", "Tim Fennell"]
 license = "MIT"


### PR DESCRIPTION
- refactor batch.Status to store which statuses have CloudWatch logs.
  This introduces a backwards compatible API change.
- watch_job does not skip over cloud logs (#7)
- better handling of exceptions while print logs while watching a batch job
- bumping minor version as we have backwards incompatible change